### PR TITLE
Update README.md for correct usage of ./ in foldername_keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Supports those extensions: **JXL AVIF WebP jpg jpeg j2k jp2 png gif tiff bmp**
 | `filename_prefix` |  String prefix added to files. |
 | `filename_keys` | Comma separated string with sampler parameters to add to filename. E.g: `sampler_name, scheduler, cfg, denoise` Added to filename in written order. `resolution`  also works. `vae_name` `model_name` (upscale model), `ckpt_name` (checkpoint) are others that should work. Here you can try any parameter name of any node. As long as the parameter has the same variable name defined in the `prompt` object they should work. The same applies to `foldername_keys`. |
 | `foldername_prefix` | String prefix added to folders. |
-| `foldername_keys` | Comma separated string with _sampler_ parameters to add to foldername. Add more subfolders by prepending "./" to the key name. |
+| `foldername_keys` | Comma separated string with _sampler_ parameters to add to foldername. Add more subfolders by writing a "./" separated with commas. For example: `sampler_name, ./, ckpt_name` |
 | `delimiter` | **now a free field** Delimiter = 1 character, can be anything your file system supports. Windows users should still use "/" for subfolders. |
 | `save_job_data` | If enabled, saves information about each job as entries in a `jobs.json` text file, inside the generated folder. Mulitple options for saving `prompt`, `basic data`, `sampler settings`, `loaded models`. |
 | `job_data_per_image` | When enabled, saves individual job data files for each image. |


### PR DESCRIPTION
This doesn't work:
`ckpt_name./ckpt_name`
It creates subfolder with the literal string name of `ckpt_name` inside of another folder called `ckpt_name`.

This doesn't work either:
`ckpt_name, ./ckpt_name`

The first "ckpt_name" is converted correctly, but the one with `./ckpt_name` creates a folder called "ckpt_name".

This works:

`ckpt_name, ./, ckpt_name`


That means that this comment in the README.ME isn't correct:
```
Comma separated string with _sampler_ parameters to add to foldername. Add more subfolders by prepending "./" to the key name.
```