### PR TITLE
drag-and-drop workflow recovery for JXL and AVIF, brotli compression metadata (10-20% of json size)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Supports those extensions: **JXL AVIF WebP jpg jpeg j2k jp2 png gif tiff bmp**
 * Customize the folder, sub-folders, and filenames of your images! 
 * Save data about the generated job (sampler, prompts, models) as entries in a `json` (text) file, in each folder.
 * Use the values of ANY node's widget, by simply adding its badge number in the form _id.widget_name_
-* Warning: ComfyUI can only load prompts from PNG and WebP atm
+* Supports workflow recovery from JXL, AVIF, WebP images with embedded metadata
 
 
 <br>
@@ -105,11 +105,13 @@ There is a requirements.txt that will take care of that, but just in case:
 - python 10.6+
 - numpy
 - pillow
+- imagecodecs (JXL/AVIF encode/decode)
+- brotli (metadata compression)
 - pillow-avif-plugin
 - pillow-jxl-plugin
 
 ```
-pip install numpy pillow pillow-avif-plugin pillow-jxl-plugin
+pip install numpy pillow imagecodecs brotli pillow-avif-plugin pillow-jxl-plugin
 ```
 
 ### Tested on / up to:
@@ -142,7 +144,7 @@ Disclaimer: Does not check for illegal characters entered in file or folder name
 Tested and working with default samplers, Efficiency nodes, UltimateSDUpscale, ComfyRoll, composer, NegiTools, and 45 other nodes.
 
 #
-Quality and compression settings: min = 1, default is **90**, max = 100 will activate **lossless** for AVIF and WEBP only.
+Quality and compression settings: min = 1, default is **90**, max = 100 will activate **lossless** for JXL, AVIF and WEBP.
 
 Quick comparison of size per extension, for the same 512x512 picture, with similar visual quality:
 | Ext | Compression | Maker | Size | Compression |
@@ -174,24 +176,33 @@ PNG compression 0-9 is fixed at level 4 for the following reason: ***zero** comp
 
 
 #
-About extensions WebP AVIF JPEG JXL: ComfyUI can only load PNG and WebP atm... Feel free to ask ComfyUI team to add support for AVIF/jpeg/JXL!
+JXL and AVIF images support workflow recovery via embedded compressed metadata (Brotli). ComfyUI can load them through drag & drop.
 
-The metadata Are included under the **EXIF** tags IFD below, as defined [here](https://exiftool.org/TagNames/EXIF.html)
-WAS Node Suite also use those tags. They must be next to each other in order to Comfy to be able to load them with drag and drop.
+Metadata is stored as Brotli-compressed JSON inside a custom ISOBMFF `brob` box (for JXL/AVIF) or in EXIF tags (for WebP/JPEG/PNG).
 
-| Data | EXIF | Name | String looks like |
-| --- | --- | --- | --- |
-| prompt | 0x010f | Make | Prompt: {"5" ... } |
-| workflow | 0x010e | ImageDescription | Workflow: {"5" ... } |
+| Format | Storage | Compression |
+| --- | --- | --- |
+| JXL / AVIF | custom `brob` ISOBMFF box | Brotli |
+| WebP / JPEG / PNG | EXIF tags 0x010f (Make), 0x010e (ImageDescription) | none |
 
 You can retrieve the prompt manually with [exiftool](https://exiftool.org/), here are some example commands:
 - `exiftool -Parameters -Prompt -Workflow image.png`
-- `exiftool -Parameters -UserComment -ImageDescription image.{jpg|jpeg|webp|avif|jxl}`
+- `exiftool -Parameters -UserComment -ImageDescription image.{jpg|jpeg|webp}`
+- For JXL/AVIF with brob box: use a hex editor or the `/api/jxl_metadata` server route
 
 #
-[JPEG XL is a heated debate on chromium forum](https://issues.chromium.org/issues/40168998#comment85) and if true, that Google is working on WebP2, JXL is unlikely to take off any day soon. Proponents arguably declare with no proof, that jxl is better and faster than the current best codec: AVIF. But again, without support from the industry, it's going nowhere.
+### Browser support for JXL
 
-I tested with compression 90 and it's good compared to WebP, with a caveat. The compression offered by pillow is 3x lower then Image Magick for the same level. No idea why.
+JXL images can be viewed directly in the browser (drag & drop from ComfyUI).
+
+**Chrome/Edge/Brave:**
+1. Open `chrome://flags/#enable-jxl-image-format` in the address bar
+2. Find `Enable JXL image format` and switch from `Default` to `Enabled`
+3. Restart the browser
+
+**Firefox:**
+- Stable release (152+, June 16 2026): open `about:config`, set `image.jxl.enabled` to `true`
+- Nightly: JXL is available out of the box
 
 
 #

--- a/__init__.py
+++ b/__init__.py
@@ -17,14 +17,45 @@ WEB_DIRECTORY = "./web"
 
 __all__ = ['NODE_CLASS_MAPPINGS', 'NODE_DISPLAY_NAME_MAPPINGS', "WEB_DIRECTORY"]
 
+import math
+import logging
+
 from aiohttp import web
 from server import PromptServer
 from pathlib import Path
 
+logger = logging.getLogger('save_image_extended')
+
+
+def _clean(v):
+    """Sanitize NaN/Inf floats for JSON serialization."""
+    if isinstance(v, float) and (math.isnan(v) or math.isinf(v)):
+        return None
+    if isinstance(v, dict):
+        return {k: _clean(v2) for k, v2 in v.items()}
+    if isinstance(v, (list, tuple)):
+        return [_clean(v2) for v2 in v]
+    return v
+
+
 if hasattr(PromptServer, "instance"):
-  # NOTE: we add an extra static path to avoid comfy mechanism
-  # that loads every script in web.
-  PromptServer.instance.app.add_routes(
-      [web.static("/save_image_extended", (Path(__file__).parent.absolute() / "assets").as_posix())]
-  )
+    # Server route for JXL/AVIF metadata extraction (workflow recovery)
+    @PromptServer.instance.routes.post('/api/jxl_metadata')
+    async def jxl_metadata(request):
+        try:
+            body = await request.read()
+            if len(body) < 12:
+                return web.json_response({})
+            from .jxl_io import extract_isobmff_metadata
+            meta = extract_isobmff_metadata(body)
+            return web.json_response(_clean(meta))
+        except Exception:
+            logger.warning('Failed to extract JXL/AVIF metadata', exc_info=True)
+            return web.json_response({}, status=400)
+
+    # NOTE: we add an extra static path to avoid comfy mechanism
+    # that loads every script in web.
+    PromptServer.instance.app.add_routes(
+        [web.static("/save_image_extended", (Path(__file__).parent.absolute() / "assets").as_posix())]
+    )
 

--- a/jxl_io.py
+++ b/jxl_io.py
@@ -1,0 +1,317 @@
+"""JPEG XL and AVIF ISOBMFF container utilities with Brotli-compressed metadata.
+
+Provides encode/decode for both formats with prompt/workflow metadata stored
+in a custom ISOBMFF 'brob' box (type tag 'comf') using Brotli compression.
+"""
+
+import json
+import math
+import struct
+
+import numpy as np
+
+try:
+    import brotli
+    _BROTLI_AVAILABLE = True
+except ImportError:
+    _BROTLI_AVAILABLE = False
+
+try:
+    import imagecodecs
+    _JXL_AVAILABLE = hasattr(imagecodecs, 'jpegxl_encode')
+    _AVIF_AVAILABLE = hasattr(imagecodecs, 'avif_encode')
+except ImportError:
+    imagecodecs = None
+    _JXL_AVAILABLE = False
+    _AVIF_AVAILABLE = False
+
+
+# ── Constants ──────────────────────────────────────────────────────────────
+
+_JXL_SIG = struct.pack('>I', 12) + b'JXL ' + bytes([0x0d, 0x0a, 0x87, 0x0a])
+
+_JXL_FTYP = (
+    struct.pack('>I', 20)
+    + b'ftyp'
+    + b'jxl '
+    + struct.pack('>I', 0)
+    + b'jxl '
+)
+
+
+# ── ISOBMFF Container Utilities ───────────────────────────────────────────
+
+def _make_box(box_type: bytes, data: bytes) -> bytes:
+    size = 8 + len(data)
+    return struct.pack('>I', size) + box_type + data
+
+
+def _parse_boxes(data: bytes, offset: int = 0) -> list[dict]:
+    boxes = []
+    while offset + 8 <= len(data):
+        size = struct.unpack('>I', data[offset:offset + 4])[0]
+        box_type = data[offset + 4:offset + 8]
+        if size == 0:
+            break
+        if size < 8 or offset + size > len(data):
+            break
+        box_data = data[offset + 8:offset + size]
+        boxes.append({
+            'type': box_type,
+            'data': box_data,
+            'size': size,
+            'offset': offset,
+        })
+        offset += size
+    return boxes
+
+
+def _find_box(boxes: list[dict], box_type: bytes):
+    for box in boxes:
+        if box['type'] == box_type:
+            return box
+    return None
+
+
+# ── Brotli Compression ─────────────────────────────────────────────────────
+
+def _compress_metadata(data: bytes) -> bytes | None:
+    if not _BROTLI_AVAILABLE:
+        return None
+    return brotli.compress(data)
+
+
+def _decompress_metadata(data: bytes) -> bytes | None:
+    if not _BROTLI_AVAILABLE:
+        return None
+    try:
+        return brotli.decompress(data)
+    except brotli.error:
+        return None
+
+
+# ── Metadata Serialization ─────────────────────────────────────────────────
+
+def _clean_nan(obj):
+    if isinstance(obj, float):
+        if math.isnan(obj) or math.isinf(obj):
+            return None
+        return obj
+    if isinstance(obj, dict):
+        return {k: _clean_nan(v) for k, v in obj.items()}
+    if isinstance(obj, (list, tuple)):
+        return [_clean_nan(v) for v in obj]
+    return obj
+
+
+def _build_metadata_blob(prompt: dict | None, extra_pnginfo: dict | None) -> bytes:
+    metadata = {}
+    if prompt is not None:
+        metadata['prompt'] = _clean_nan(prompt)
+    if extra_pnginfo is not None:
+        for key, value in extra_pnginfo.items():
+            metadata[key] = _clean_nan(value)
+    return json.dumps(metadata, allow_nan=False).encode('utf-8')
+
+
+def _parse_metadata_blob(raw: bytes) -> dict:
+    try:
+        return json.loads(raw.decode('utf-8'))
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        return {}
+
+
+# ── Container Detection ────────────────────────────────────────────────────
+
+def is_jxl_container(data: bytes) -> bool:
+    """Check if bytes are a JXL ISOBMFF container (not raw codestream)."""
+    if len(data) < 32:
+        return False
+    return (
+        struct.unpack('>I', data[:4])[0] == 12
+        and data[4:8] == b'JXL '
+        and data[8:12] == bytes([0x0d, 0x0a, 0x87, 0x0a])
+        and struct.unpack('>I', data[12:16])[0] == 20
+        and data[16:20] == b'ftyp'
+        and data[20:24] == b'jxl '
+    )
+
+
+def is_avif_container(data: bytes) -> bool:
+    """Check if bytes are an AVIF file (ftyp box with 'avif' brand)."""
+    if len(data) < 16:
+        return False
+    boxes = _parse_boxes(data)
+    ftyp = _find_box(boxes, b'ftyp')
+    if ftyp is None:
+        return False
+    return b'avif' in ftyp['data']
+
+
+# ── Brob Box Metadata Extraction ──────────────────────────────────────────
+
+def _extract_from_brob_box(brob_box: dict) -> dict:
+    """Extract and decompress metadata from a brob box payload."""
+    if brob_box['data'][:4] != b'comf':
+        return {}
+    payload = brob_box['data'][4:]
+    decompressed = _decompress_metadata(payload)
+    if decompressed is not None:
+        return _parse_metadata_blob(decompressed)
+    return _parse_metadata_blob(payload)
+
+
+def extract_isobmff_metadata(data: bytes) -> dict:
+    """Extract metadata from any ISOBMFF file (JXL or AVIF) with a brob box."""
+    if is_jxl_container(data):
+        boxes = _parse_boxes(data, offset=12)
+    elif is_avif_container(data):
+        boxes = _parse_boxes(data, offset=0)
+    else:
+        return {}
+    brob = _find_box(boxes, b'brob')
+    if brob is not None:
+        return _extract_from_brob_box(brob)
+    return {}
+
+
+# ── Generic brob injector (for AVIF post-processing) ─────────────────────
+
+def _append_brob_box(data: bytes, metadata_blob: bytes) -> bytes:
+    """Append a brob box at the end of an ISOBMFF file (safe for AVIF offsets)."""
+    compressed = _compress_metadata(metadata_blob)
+    brob_content = b'comf' + (compressed if compressed is not None else metadata_blob)
+    return data + _make_box(b'brob', brob_content)
+
+
+# ── JXL Encode ─────────────────────────────────────────────────────────────
+
+def encode_jxl_with_metadata(
+    image: np.ndarray,
+    quality: int = 100,
+    prompt: dict | None = None,
+    extra_pnginfo: dict | None = None,
+) -> bytes:
+    """Encode a numpy image (HxWxC, uint8) to a JXL container with compressed metadata.
+
+    Metadata is always compressed with Brotli when available (no opt-out).
+    Quality 100 = lossless. Lower values = more compression.
+    """
+    if not _JXL_AVAILABLE:
+        raise RuntimeError(
+            'imagecodecs JXL support not available. Install with: pip install imagecodecs'
+        )
+
+    if quality >= 100:
+        codestream = imagecodecs.jpegxl_encode(image, lossless=True)
+    else:
+        distance = (100 - quality) * 0.15
+        codestream = imagecodecs.jpegxl_encode(image, lossless=False, distance=distance)
+
+    container = _JXL_SIG + _JXL_FTYP
+    container += _make_box(b'jxlc', codestream)
+
+    if prompt is not None or extra_pnginfo is not None:
+        raw_meta = _build_metadata_blob(prompt, extra_pnginfo)
+        compressed = _compress_metadata(raw_meta)
+        brob_content = b'comf' + (compressed if compressed is not None else raw_meta)
+        container += _make_box(b'brob', brob_content)
+
+    return container
+
+
+# ── JXL Decode ─────────────────────────────────────────────────────────────
+
+def decode_jxl_to_numpy(data: bytes):
+    """Decode a JXL file to (numpy_array, metadata_dict).
+
+    Handles both ISOBMFF container and raw codestream input.
+    """
+    if not _JXL_AVAILABLE:
+        raise RuntimeError('imagecodecs JXL support not available')
+
+    metadata = {}
+
+    if is_jxl_container(data):
+        boxes = _parse_boxes(data, offset=12)
+        brob = _find_box(boxes, b'brob')
+        if brob is not None:
+            metadata = _extract_from_brob_box(brob)
+
+        codestream = None
+        jxlc = _find_box(boxes, b'jxlc')
+        if jxlc is not None:
+            codestream = jxlc['data']
+        else:
+            for b in boxes:
+                if b['type'] == b'jxlp' and len(b['data']) > 1:
+                    codestream = b['data'][1:]
+                    break
+        if codestream is None:
+            raise ValueError('No JXL codestream found in container')
+    else:
+        codestream = data
+
+    image = imagecodecs.jpegxl_decode(codestream)
+    return image, metadata
+
+
+# ── AVIF Encode ────────────────────────────────────────────────────────────
+
+def encode_avif_with_metadata(
+    image: np.ndarray,
+    quality: int = 90,
+    prompt: dict | None = None,
+    extra_pnginfo: dict | None = None,
+) -> bytes:
+    """Encode a numpy image (HxWxC, uint8) to an AVIF file with compressed metadata.
+
+    Metadata is appended as a top-level 'brob' box (safe — does not shift iloc offsets).
+    """
+    if not _AVIF_AVAILABLE:
+        raise RuntimeError(
+            'imagecodecs AVIF support not available. Install with: pip install imagecodecs'
+        )
+
+    if quality >= 100:
+        data = imagecodecs.avif_encode(image, level=100)
+    else:
+        data = imagecodecs.avif_encode(image, level=quality)
+
+    if prompt is not None or extra_pnginfo is not None:
+        raw_meta = _build_metadata_blob(prompt, extra_pnginfo)
+        data = _append_brob_box(data, raw_meta)
+
+    return data
+
+
+# ── AVIF Decode ────────────────────────────────────────────────────────────
+
+def decode_avif_to_numpy(data: bytes):
+    """Decode an AVIF file to (numpy_array, metadata_dict)."""
+    if not _AVIF_AVAILABLE:
+        raise RuntimeError('imagecodecs AVIF support not available')
+
+    metadata = extract_isobmff_metadata(data)
+    image = imagecodecs.avif_decode(data)
+    return image, metadata
+
+
+# ── Public API ─────────────────────────────────────────────────────────────
+
+BROTLI_AVAILABLE = _BROTLI_AVAILABLE
+JXL_AVAILABLE = _JXL_AVAILABLE
+AVIF_AVAILABLE = _AVIF_AVAILABLE
+
+__all__ = [
+    'encode_jxl_with_metadata',
+    'decode_jxl_to_numpy',
+    'encode_avif_with_metadata',
+    'decode_avif_to_numpy',
+    'extract_isobmff_metadata',
+    'is_jxl_container',
+    'is_avif_container',
+    'BROTLI_AVAILABLE',
+    'JXL_AVAILABLE',
+    'AVIF_AVAILABLE',
+]

--- a/jxl_io.py
+++ b/jxl_io.py
@@ -78,7 +78,7 @@ def _find_box(boxes: list[dict], box_type: bytes):
 def _compress_metadata(data: bytes) -> bytes | None:
     if not _BROTLI_AVAILABLE:
         return None
-    return brotli.compress(data)
+    return brotli.compress(data, mode=brotli.MODE_TEXT, quality=11)
 
 
 def _decompress_metadata(data: bytes) -> bytes | None:
@@ -263,6 +263,8 @@ def encode_avif_with_metadata(
     quality: int = 90,
     prompt: dict | None = None,
     extra_pnginfo: dict | None = None,
+    speed: int = 6,
+    numthreads: int = 4,
 ) -> bytes:
     """Encode a numpy image (HxWxC, uint8) to an AVIF file with compressed metadata.
 
@@ -274,9 +276,9 @@ def encode_avif_with_metadata(
         )
 
     if quality >= 100:
-        data = imagecodecs.avif_encode(image, level=100)
+        data = imagecodecs.avif_encode(image, level=100, speed=speed, numthreads=numthreads)
     else:
-        data = imagecodecs.avif_encode(image, level=quality)
+        data = imagecodecs.avif_encode(image, level=quality, speed=speed, numthreads=numthreads)
 
     if prompt is not None or extra_pnginfo is not None:
         raw_meta = _build_metadata_blob(prompt, extra_pnginfo)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
   "pillow", 
   "pillow-avif-plugin", 
   "pillow-jxl-plugin", 
+  "brotli", 
   "comfyui-frontend-package>=1.20.0"
 ]
 classifiers = [

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ imagecodecs
 pillow
 pillow-avif-plugin
 pillow-jxl-plugin
-brotli
+brotli>=1.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,9 @@
-# piexif    # for testing
-# jpegxl support: imagecodecs will bring libjxl 0.9.0
-# imagecodecs   # pillow-jxl-plugin is simpler
-
+# imagecodecs provides JXL/AVIF encode/decode with full ISOBMFF control
+# brotli provides metadata compression for JXL/AVIF custom boxes
 numpy
 piexif
 imagecodecs
 pillow
 pillow-avif-plugin
 pillow-jxl-plugin
+brotli

--- a/save_image_extended.py
+++ b/save_image_extended.py
@@ -9,6 +9,21 @@ import folder_paths
 
 import pprint
 import numpy
+
+# imagecodecs-based JXL/AVIF with Brotli-compressed metadata brob box
+try:
+    from .jxl_io import (
+        encode_jxl_with_metadata,
+        encode_avif_with_metadata,
+        decode_jxl_to_numpy,
+        decode_avif_to_numpy,
+        extract_isobmff_metadata,
+        JXL_AVAILABLE as JXL_IC,
+        AVIF_AVAILABLE as AVIF_IC,
+    )
+except ImportError:
+    JXL_IC = False
+    AVIF_IC = False
 # import piexif
 # import piexif.helper
 
@@ -217,10 +232,13 @@ ComfyUI can only load PNG and WebP at the moment, AVIF is a PR that was sadly dr
       # return "cannot be empty or 0"
     # return True
 
-  # TODO: see how that works and how that can help
-  # @classmethod
-  # def IS_CHANGED(self, **kwargs):
-      # return float("nan")
+  @classmethod
+  def IS_CHANGED(cls, **kwargs):
+      return float("nan")
+
+  @classmethod
+  def VALIDATE_INPUTS(cls, **kwargs):
+      return True
 
   def get_subfolder_path(self, image_path, output_path):
     image_path = Path(image_path).resolve()
@@ -748,13 +766,49 @@ ComfyUI can only load PNG and WebP at the moment, AVIF is a PR that was sadly dr
     # TODO: see if convert_hdr_to_8bit=False make a change
     # https://pillow.readthedocs.io/en/stable/handbook/image-file-formats.html
     
-    if output_ext in ['.avif', '.webp', '.jxl']:
-      if save_metadata: kwargs["exif"] = self.genMetadataEXIF(img, prompt, extra_pnginfo)
+    if output_ext == '.jxl':
+      if JXL_IC:
+        numpy_array = numpy.array(img)
+        jxl_bytes = encode_jxl_with_metadata(
+            numpy_array,
+            quality=quality,
+            prompt=prompt if save_metadata else None,
+            extra_pnginfo=extra_pnginfo if save_metadata else None,
+        )
+        with open(image_path, 'wb') as f:
+            f.write(jxl_bytes)
+        return
+      if save_metadata: kwargs['exif'] = self.genMetadataEXIF(img, prompt, extra_pnginfo)
       if quality == 100:
-        kwargs["lossless"] = True
+        kwargs['lossless'] = True
       else:
-        kwargs["quality"] = quality
-      kwargs["optimize"] = self.optimize_image
+        kwargs['quality'] = quality
+      kwargs['optimize'] = self.optimize_image
+    elif output_ext == '.avif':
+      if AVIF_IC:
+        numpy_array = numpy.array(img)
+        avif_bytes = encode_avif_with_metadata(
+            numpy_array,
+            quality=quality,
+            prompt=prompt if save_metadata else None,
+            extra_pnginfo=extra_pnginfo if save_metadata else None,
+        )
+        with open(image_path, 'wb') as f:
+            f.write(avif_bytes)
+        return
+      if save_metadata: kwargs['exif'] = self.genMetadataEXIF(img, prompt, extra_pnginfo)
+      if quality == 100:
+        kwargs['lossless'] = True
+      else:
+        kwargs['quality'] = quality
+      kwargs['optimize'] = self.optimize_image
+    elif output_ext == '.webp':
+      if save_metadata: kwargs['exif'] = self.genMetadataEXIF(img, prompt, extra_pnginfo)
+      if quality == 100:
+        kwargs['lossless'] = True
+      else:
+        kwargs['quality'] = quality
+      kwargs['optimize'] = self.optimize_image
     if output_ext in ['.j2k', '.jp2', '.jpc', '.jpf', '.jpx', '.j2c']:
       if save_metadata: kwargs["exif"] = self.genMetadataEXIF(img, prompt, extra_pnginfo)
       if quality < 100:

--- a/web/jxlMetadata.js
+++ b/web/jxlMetadata.js
@@ -1,0 +1,250 @@
+import { app } from "../../scripts/app.js";
+import { api } from "../../scripts/api.js";
+
+// ── ISOBMFF Container Parser (JXL & AVIF) ───────────────────────────────
+
+function bytesToString(bytes) {
+  return new TextDecoder("iso-8859-1").decode(bytes);
+}
+
+function parseBoxes(data) {
+  var boxes = [];
+  var offset = 0;
+  var view = new DataView(data);
+  while (offset + 8 <= data.byteLength) {
+    var size = view.getUint32(offset);
+    if (size === 0) break;
+    if (size < 8 || offset + size > data.byteLength) break;
+    var type = bytesToString(new Uint8Array(data, offset + 4, 4));
+    boxes.push({ type: type, data: new Uint8Array(data, offset + 8, size - 8), size: size });
+    offset += size;
+  }
+  return boxes;
+}
+
+var MAGIC_JXL = [
+  0x00, 0x00, 0x00, 0x0c,
+  0x4a, 0x58, 0x4c, 0x20,
+  0x0d, 0x0a, 0x87, 0x0a,
+];
+
+function isJxlContainer(buffer) {
+  if (buffer.byteLength < 32) return false;
+  var u8 = new Uint8Array(buffer);
+  for (var i = 0; i < 12; i++) {
+    if (u8[i] !== MAGIC_JXL[i]) return false;
+  }
+  return (
+    u8[12] === 0x00 && u8[13] === 0x00 && u8[14] === 0x00 && u8[15] === 0x14 &&
+    u8[16] === 0x66 && u8[17] === 0x74 && u8[18] === 0x79 && u8[19] === 0x70 &&
+    u8[20] === 0x6a && u8[21] === 0x78 && u8[22] === 0x6c && u8[23] === 0x20
+  );
+}
+
+function isAvifContainer(buffer) {
+  if (buffer.byteLength < 16) return false;
+  var boxes = parseBoxes(buffer);
+  for (var i = 0; i < boxes.length; i++) {
+    if (boxes[i].type === "ftyp") {
+      var brandStr = bytesToString(boxes[i].data);
+      return brandStr.indexOf("avif") !== -1;
+    }
+  }
+  return false;
+}
+
+// ── Brotli Decompression ────────────────────────────────────────────────
+
+var _brotliFormats = [];
+function detectBrotliFormat() {
+  if (_brotliFormats.length > 0) return _brotliFormats;
+  if (typeof DecompressionStream === "undefined") return [];
+  var candidates = ["brotli", "br"];
+  for (var i = 0; i < candidates.length; i++) {
+    try { new DecompressionStream(candidates[i]); _brotliFormats.push(candidates[i]); } catch (e) {}
+  }
+  return _brotliFormats;
+}
+
+async function decompressBrotli(compressed) {
+  var formats = detectBrotliFormat();
+  if (formats.length === 0) return null;
+  for (var f = 0; f < formats.length; f++) {
+    try {
+      var cs = new DecompressionStream(formats[f]);
+      var blob = new Blob([compressed]);
+      var stream = blob.stream().pipeThrough(cs);
+      var reader = stream.getReader();
+      var chunks = [];
+      while (true) {
+        var r = await reader.read();
+        if (r.done) break;
+        chunks.push(r.value);
+      }
+      var total = chunks.reduce(function (s, c) { return s + c.byteLength; }, 0);
+      var result = new Uint8Array(total);
+      var off = 0;
+      for (var i = 0; i < chunks.length; i++) {
+        result.set(chunks[i], off);
+        off += chunks[i].byteLength;
+      }
+      return result;
+    } catch (e) {}
+  }
+  return null;
+}
+
+// ── Metadata Extraction ─────────────────────────────────────────────────
+
+async function getMetadataFromBuffer(buffer) {
+  var boxes = parseBoxes(buffer);
+  for (var i = 0; i < boxes.length; i++) {
+    if (boxes[i].type === "brob") {
+      var innerType = bytesToString(boxes[i].data.subarray(0, 4));
+      if (innerType !== "comf") continue;
+      var compressed = boxes[i].data.subarray(4);
+      var decompressed = await decompressBrotli(compressed);
+      if (decompressed) {
+        try {
+          return JSON.parse(new TextDecoder("utf-8").decode(decompressed));
+        } catch (e) {}
+      }
+      try {
+        return JSON.parse(new TextDecoder("utf-8").decode(compressed));
+      } catch (e) {}
+    }
+  }
+  return null;
+}
+
+async function getMetadataFromFile(file) {
+  try {
+    var buffer = await file.arrayBuffer();
+    return await getMetadataFromBuffer(buffer);
+  } catch (e) { return null; }
+}
+
+async function getMetadataFromServer(file) {
+  try {
+    var resp = await api.fetchApi("/jxl_metadata", {
+      method: "POST",
+      body: file,
+      headers: { "Content-Type": "application/octet-stream" }
+    });
+    if (!resp.ok) return null;
+    return await resp.json();
+  } catch (e) { return null; }
+}
+
+var _supportedExts = [".jxl", ".avif"];
+
+// ── Register Extension ─────────────────────────────────────────────────
+
+app.registerExtension({
+  name: "save_image_extended.JxlAvifMetadata",
+
+  async setup() {
+    patchHandleFile();
+  },
+});
+
+// ── Patch app.handleFile ────────────────────────────────────────────────
+
+function patchHandleFile() {
+  if (typeof app.handleFile !== "function") return;
+  if (app._sieJxlAvifPatched) return;
+  app._sieJxlAvifPatched = true;
+
+  var orig = app.handleFile.bind(app);
+  app.handleFile = async function (file, source, opts) {
+    if (file && file.name) {
+      var lower = file.name.toLowerCase();
+      var isSupported = false;
+      for (var i = 0; i < _supportedExts.length; i++) {
+        if (lower.endsWith(_supportedExts[i])) { isSupported = true; break; }
+      }
+      if (isSupported) {
+        var meta = await getMetadataFromFile(file);
+        if (!meta) { meta = await getMetadataFromServer(file); }
+        if (meta) {
+          var name = file.name.replace(/\.\w+$/, "");
+          if (meta.workflow) {
+            var wf = typeof meta.workflow === "string" ? JSON.parse(meta.workflow) : meta.workflow;
+            if (wf && typeof wf === "object") {
+              await app.loadGraphData(wf, true, true, name, {});
+              return;
+            }
+          }
+          if (meta.prompt) {
+            var p = typeof meta.prompt === "string" ? JSON.parse(meta.prompt) : meta.prompt;
+            if (p && app.isApiJson(p)) {
+              app.loadApiJson(p, name);
+              return;
+            }
+          }
+        }
+      }
+    }
+    return orig(file, source, opts);
+  };
+}
+
+// ── Capture-phase drop interceptor ──────────────────────────────────────
+
+document.addEventListener("dragover", function (e) {
+  try {
+    var dt = e.dataTransfer;
+    if (!dt || !dt.files) return;
+    for (var i = 0; i < dt.files.length; i++) {
+      var name = dt.files[i].name;
+      if (name) {
+        var lower = name.toLowerCase();
+        for (var j = 0; j < _supportedExts.length; j++) {
+          if (lower.endsWith(_supportedExts[j])) {
+            e.preventDefault();
+            e.stopPropagation();
+            return;
+          }
+        }
+      }
+    }
+  } catch (ex) {}
+}, true);
+
+document.addEventListener("drop", function (e) {
+  try {
+    var dt = e.dataTransfer;
+    if (!dt || !dt.files) return;
+    for (var i = 0; i < dt.files.length; i++) {
+      var f = dt.files[i];
+      if (!f || !f.name) continue;
+      var lower = f.name.toLowerCase();
+      var isSupported = false;
+      for (var j = 0; j < _supportedExts.length; j++) {
+        if (lower.endsWith(_supportedExts[j])) { isSupported = true; break; }
+      }
+      if (!isSupported) continue;
+
+      e.preventDefault();
+      e.stopPropagation();
+      (async function () {
+        var meta = await getMetadataFromFile(f);
+        if (!meta) { meta = await getMetadataFromServer(f); }
+        if (meta) {
+          if (meta.workflow) {
+            var wf = typeof meta.workflow === "string" ? JSON.parse(meta.workflow) : meta.workflow;
+            if (wf && typeof wf === "object") {
+              await app.loadGraphData(wf, true, true, f.name.replace(/\.\w+$/, ""), {});
+              return;
+            }
+          }
+          if (meta.prompt) {
+            var p = typeof meta.prompt === "string" ? JSON.parse(meta.prompt) : meta.prompt;
+            if (p && app.isApiJson(p)) { app.loadApiJson(p, f.name.replace(/\.\w+$/, "")); }
+          }
+        }
+      })();
+      return;
+    }
+  } catch (ex) {}
+}, true);

--- a/web/jxlMetadata.js
+++ b/web/jxlMetadata.js
@@ -41,19 +41,13 @@ function isJxlContainer(buffer) {
   );
 }
 
-function isAvifContainer(buffer) {
-  if (buffer.byteLength < 16) return false;
-  var boxes = parseBoxes(buffer);
-  for (var i = 0; i < boxes.length; i++) {
-    if (boxes[i].type === "ftyp") {
-      var brandStr = bytesToString(boxes[i].data);
-      return brandStr.indexOf("avif") !== -1;
-    }
-  }
-  return false;
-}
-
 // ── Brotli Decompression ────────────────────────────────────────────────
+// NOTE: Brotli DecompressionStream is NOT available in Chromium/Chrome.
+// It is supported in Firefox and Safari.
+// The server-side fallback route (/api/jxl_metadata) handles cases where
+// client-side brotli decompression is unavailable.
+// Once Chromium ships native Brotli DecompressionStream support,
+// the server fallback path can be removed.
 
 var _brotliFormats = [];
 function detectBrotliFormat() {
@@ -96,7 +90,7 @@ async function decompressBrotli(compressed) {
 
 // ── Metadata Extraction ─────────────────────────────────────────────────
 
-async function getMetadataFromBuffer(buffer) {
+async function getWorkflowFromBuffer(buffer) {
   var boxes = parseBoxes(buffer);
   for (var i = 0; i < boxes.length; i++) {
     if (boxes[i].type === "brob") {
@@ -117,14 +111,14 @@ async function getMetadataFromBuffer(buffer) {
   return null;
 }
 
-async function getMetadataFromFile(file) {
+async function getWorkflowFromFile(file) {
   try {
     var buffer = await file.arrayBuffer();
-    return await getMetadataFromBuffer(buffer);
+    return await getWorkflowFromBuffer(buffer);
   } catch (e) { return null; }
 }
 
-async function getMetadataFromServer(file) {
+async function getWorkflowFromServer(file) {
   try {
     var resp = await api.fetchApi("/jxl_metadata", {
       method: "POST",
@@ -136,7 +130,25 @@ async function getMetadataFromServer(file) {
   } catch (e) { return null; }
 }
 
+// ── Try to load workflow from .jxl / .avif metadata ─────────────────────
+// Returns true if workflow was loaded, false to fall through to default.
+
+async function tryLoadWorkflow(file) {
+  var meta = await getWorkflowFromFile(file);
+  if (!meta) { meta = await getWorkflowFromServer(file); }
+  if (meta && meta.workflow) {
+    var name = file.name.replace(/\.\w+$/, "");
+    var wf = typeof meta.workflow === "string" ? JSON.parse(meta.workflow) : meta.workflow;
+    if (wf && typeof wf === "object") {
+      await app.loadGraphData(wf, true, true, name, {});
+      return true;
+    }
+  }
+  return false;
+}
+
 var _supportedExts = [".jxl", ".avif"];
+var _unpatchedHandleFile = null;
 
 // ── Register Extension ─────────────────────────────────────────────────
 
@@ -149,63 +161,43 @@ app.registerExtension({
 });
 
 // ── Patch app.handleFile ────────────────────────────────────────────────
+// Only loads workflow from embedded metadata.
+// Falls through to default ComfyUI handler for all other cases (image load).
 
 function patchHandleFile() {
   if (typeof app.handleFile !== "function") return;
   if (app._sieJxlAvifPatched) return;
   app._sieJxlAvifPatched = true;
 
-  var orig = app.handleFile.bind(app);
+  _unpatchedHandleFile = app.handleFile.bind(app);
   app.handleFile = async function (file, source, opts) {
-    if (file && file.name) {
-      var lower = file.name.toLowerCase();
-      var isSupported = false;
-      for (var i = 0; i < _supportedExts.length; i++) {
-        if (lower.endsWith(_supportedExts[i])) { isSupported = true; break; }
-      }
-      if (isSupported) {
-        var meta = await getMetadataFromFile(file);
-        if (!meta) { meta = await getMetadataFromServer(file); }
-        if (meta) {
-          var name = file.name.replace(/\.\w+$/, "");
-          if (meta.workflow) {
-            var wf = typeof meta.workflow === "string" ? JSON.parse(meta.workflow) : meta.workflow;
-            if (wf && typeof wf === "object") {
-              await app.loadGraphData(wf, true, true, name, {});
-              return;
-            }
-          }
-          if (meta.prompt) {
-            var p = typeof meta.prompt === "string" ? JSON.parse(meta.prompt) : meta.prompt;
-            if (p && app.isApiJson(p)) {
-              app.loadApiJson(p, name);
-              return;
-            }
-          }
-        }
-      }
+    if (file && file.name && _matchesExt(file.name)) {
+      if (await tryLoadWorkflow(file)) return;
     }
-    return orig(file, source, opts);
+    return _unpatchedHandleFile(file, source, opts);
   };
 }
 
-// ── Capture-phase drop interceptor ──────────────────────────────────────
+function _matchesExt(name) {
+  var lower = name.toLowerCase();
+  for (var i = 0; i < _supportedExts.length; i++) {
+    if (lower.endsWith(_supportedExts[i])) return true;
+  }
+  return false;
+}
+
+// ── Drag/drop interceptors ──────────────────────────────────────────────
+// Allow .jxl/.avif files to be dropped (browser would otherwise reject them).
 
 document.addEventListener("dragover", function (e) {
   try {
     var dt = e.dataTransfer;
     if (!dt || !dt.files) return;
     for (var i = 0; i < dt.files.length; i++) {
-      var name = dt.files[i].name;
-      if (name) {
-        var lower = name.toLowerCase();
-        for (var j = 0; j < _supportedExts.length; j++) {
-          if (lower.endsWith(_supportedExts[j])) {
-            e.preventDefault();
-            e.stopPropagation();
-            return;
-          }
-        }
+      if (dt.files[i].name && _matchesExt(dt.files[i].name)) {
+        e.preventDefault();
+        e.stopPropagation();
+        return;
       }
     }
   } catch (ex) {}
@@ -217,31 +209,13 @@ document.addEventListener("drop", function (e) {
     if (!dt || !dt.files) return;
     for (var i = 0; i < dt.files.length; i++) {
       var f = dt.files[i];
-      if (!f || !f.name) continue;
-      var lower = f.name.toLowerCase();
-      var isSupported = false;
-      for (var j = 0; j < _supportedExts.length; j++) {
-        if (lower.endsWith(_supportedExts[j])) { isSupported = true; break; }
-      }
-      if (!isSupported) continue;
+      if (!f || !f.name || !_matchesExt(f.name)) continue;
 
       e.preventDefault();
       e.stopPropagation();
       (async function () {
-        var meta = await getMetadataFromFile(f);
-        if (!meta) { meta = await getMetadataFromServer(f); }
-        if (meta) {
-          if (meta.workflow) {
-            var wf = typeof meta.workflow === "string" ? JSON.parse(meta.workflow) : meta.workflow;
-            if (wf && typeof wf === "object") {
-              await app.loadGraphData(wf, true, true, f.name.replace(/\.\w+$/, ""), {});
-              return;
-            }
-          }
-          if (meta.prompt) {
-            var p = typeof meta.prompt === "string" ? JSON.parse(meta.prompt) : meta.prompt;
-            if (p && app.isApiJson(p)) { app.loadApiJson(p, f.name.replace(/\.\w+$/, "")); }
-          }
+        if (!(await tryLoadWorkflow(f)) && _unpatchedHandleFile) {
+          _unpatchedHandleFile(f, 'client', {});
         }
       })();
       return;


### PR DESCRIPTION
I have been dreaming of this feature since the release of this exporter, but continued to use PNG because there was no way to use metadata, save files, and import them back. I have created this workaround for exporting with compression and importing together with the workflow data.